### PR TITLE
Upgrade to .NET 10 and remediate vulnerable NuGet packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Dash Accounting System V2 is a multi-tenant simple ledger + time-tracking system for small businesses. It is an ASP.NET Core 8 Web API back end paired with a React 18 / Redux SPA front end, orchestrated locally with .NET Aspire and backed by PostgreSQL.
+Dash Accounting System V2 is a multi-tenant simple ledger + time-tracking system for small businesses. It is an ASP.NET Core 10 Web API back end paired with a React 18 / Redux SPA front end, orchestrated locally with .NET Aspire and backed by PostgreSQL.
 
 ## Solution Layout
 
 The Visual Studio solution is `src/DashAccountingSystemV2.sln` and contains five projects:
 
-- **`src/BackEnd`** (`DashAccountingSystemV2.BackEnd.csproj`) — ASP.NET Core Web API (`net8.0`). The core of the system.
+- **`src/BackEnd`** (`DashAccountingSystemV2.BackEnd.csproj`) — ASP.NET Core Web API (`net10.0`). The core of the system.
 - **`src/FrontEnd`** (`.esproj`) — React 18 + TypeScript SPA created with Create React App (`react-scripts`). Not built by `dotnet build`; managed via npm.
 - **`src/Infrastructure/DashAccountingSystemV2.Aspire.AppHost`** — .NET Aspire orchestrator that launches the back end and the npm front end together.
 - **`src/Infrastructure/DashAccountingSystemV2.Aspire.ServiceDefaults`** — shared Aspire service defaults (telemetry, health checks, service discovery).

--- a/src/BackEnd/DashAccountingSystemV2.BackEnd.csproj
+++ b/src/BackEnd/DashAccountingSystemV2.BackEnd.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>2b3006e2-bf37-4b89-badd-06c844ef21cf</UserSecretsId>
@@ -29,27 +29,34 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="ClosedXML.Report" Version="0.2.10" />
+    <PackageReference Include="ClosedXML.Report" Version="0.2.12" />
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.3" />
     <PackageReference Include="NodaTime" Version="3.1.11" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="RazorLight" Version="2.3.1" />
     <PackageReference Include="Select.HtmlToPdf.NetCore" Version="24.1.0" />
     <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Pinned transitive dependencies to resolve security advisories">
+    <!-- Select.HtmlToPdf.NetCore drags in System.Drawing.Common 4.5.1 (CVE-2021-24112, CRITICAL).
+         5.0.3 is the patched, minimal-drift version (avoids the Windows-only platform attribute added in 6.0+). -->
+    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+    <!-- ClosedXML.Report -> ClosedXML -> DocumentFormat.OpenXml drags in System.IO.Packaging 6.0.0 (HIGH). -->
+    <PackageReference Include="System.IO.Packaging" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Folder Includes">

--- a/src/FrontEnd/src/app/navMenu.css
+++ b/src/FrontEnd/src/app/navMenu.css
@@ -8,7 +8,7 @@ a.navbar-brand {
     box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
 }
 
-.dotnet-8-badge {
+.dotnet-badge {
     background-color: rgb(81 43 212);
     border: solid 1px rgb(81 43 212);
     color: #fff;

--- a/src/FrontEnd/src/app/navMenu.tsx
+++ b/src/FrontEnd/src/app/navMenu.tsx
@@ -75,7 +75,7 @@ function NavMenu({
                     to="/">
                     Dash Accounting System v2.1
                     {'\u00a0'}
-                    <span className="badge dotnet-8-badge">.NET 8</span>
+                    <span className="badge dotnet-badge">.NET 10</span>
                 </Link>
 
 

--- a/src/Infrastructure/DashAccountingSystemV2.Aspire.AppHost/DashAccountingSystemV2.Aspire.AppHost.csproj
+++ b/src/Infrastructure/DashAccountingSystemV2.Aspire.AppHost/DashAccountingSystemV2.Aspire.AppHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
   <PropertyGroup Label="Package">
     <PackageId>DashAccountingSystemV2.Aspire.AppHost</PackageId>
@@ -12,7 +12,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.0.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.NodeJs" Version="9.5.2" />
   </ItemGroup>
 

--- a/src/Infrastructure/DashAccountingSystemV2.Aspire.ServiceDefaults/DashAccountingSystemV2.Aspire.ServiceDefaults.csproj
+++ b/src/Infrastructure/DashAccountingSystemV2.Aspire.ServiceDefaults/DashAccountingSystemV2.Aspire.ServiceDefaults.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   
   <PropertyGroup Label="Build">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
@@ -18,13 +18,13 @@
   <ItemGroup Label="Package References">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/test/DashAccountingSystemV2.Tests/DashAccountingSystemV2.Tests.csproj
+++ b/test/DashAccountingSystemV2.Tests/DashAccountingSystemV2.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -22,15 +22,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="Npgsql" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/test/DashAccountingSystemV2.Tests/appsettings.UnitTests.json
+++ b/test/DashAccountingSystemV2.Tests/appsettings.UnitTests.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Port=5432;User Id=postgres;Database=dash_accounting_aspnet8"
+    "DefaultConnection": "Server=localhost;Port=5432;User Id=postgres;Database=dash_accounting;Application Name=Dash Accounting System v2.1 Unit Tests"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary

Upgrades the solution from **.NET 8 → .NET 10** and brings the NuGet dependency set from **1 critical + 5 high + several moderate/low advisories down to zero vulnerable packages** across all four projects.

## Framework

- All projects retargeted `net8.0` → `net10.0` (BackEnd, Aspire AppHost, Aspire ServiceDefaults, Tests).
- Runtime-tied packages bumped to `10.0.x` (EF Core, ASP.NET Identity EF Core, Npgsql EF Core provider, SpaProxy, EF tooling; the shared-framework `Microsoft.Extensions.*` family resolves at `10.0.9`).
- Aspire `13.0.0` → `13.4.6` (AppHost SDK + `Aspire.Hosting.AppHost`).

## Security remediation

| Advisory (severity) | Source | Fix |
|---|---|---|
| System.Text.Json / Caching.Memory / System.Formats.Asn1 (High) | transitive | cleared by the net10 shared framework |
| System.Drawing.Common 4.5.1 — CVE-2021-24112 (**Critical**) | Select.HtmlToPdf.NetCore | pin `5.0.3` (patched, minimal-drift) |
| System.IO.Packaging 6.0.0 (High) | ClosedXML.Report → ClosedXML → OpenXml | pin `10.0.0` |
| System.Linq.Dynamic.Core 1.3.8 (High) | ClosedXML.Report | bump ClosedXML.Report `0.2.10` → `0.2.12` (resolves patched, API-compatible `1.6.0.2`) |
| System.Security.Cryptography.Xml / Microsoft.Build / NuGet.* (High/Low) | Microsoft.VisualStudio.Web.CodeGeneration.Design (scaffolding-only dev tool) | remove the package |
| MessagePack 2.5.192 (High) | Aspire → StreamJsonRpc | cleared by Aspire 13.4.6 |
| OpenTelemetry.* 1.9.0 (Moderate) | ServiceDefaults (direct) | bump to 1.16.0 |

**Result:** `dotnet list package --vulnerable --include-transitive` reports **no vulnerable packages** in any of the four projects.

### Notable gotcha
`ClosedXML.Report` 0.2.10 is precompiled against the *old* `System.Linq.Dynamic.Core` 1.3.8 API. Forcing a newer version under it throws `MissingMethodException` at `XLTemplate.Generate()` (Balance Sheet / P&L Excel export → HTTP 400). Bumping ClosedXML.Report to 0.2.12 — which is built against the newer API — is the clean fix.

## Verification

- ✅ `dotnet build` clean on .NET 10 (all projects)
- ✅ 78/78 unit tests pass
- ✅ App starts on net10 (DI/scope validation OK)
- ✅ Invoice **PDF** export works (validates the System.Drawing.Common 5.0.3 pin)
- ✅ Balance Sheet + Profit & Loss **Excel** exports work (validates the ClosedXML.Report bump)
- ✅ Nav header badge now reads **.NET 10** (renamed the CSS class to a version-agnostic `dotnet-badge`)

## Note on the test project

The unit-test connection string previously pointed at a separate `dash_accounting_aspnet8` database that isn't provisioned. Per the fixtures' design (they create their own tenant/data), it now targets the same `dash_accounting` dev database via the `postgres` superuser (the app user lacks the PG15 `CREATE ON SCHEMA public` right the fixtures' `EnsureCreated`/`Migrate` need). The password still comes from the `DbPassword` user-secret.

---
🤖 *Drafted by [Claude Code](https://claude.com/claude-code) on Geoffrey's behalf.*
